### PR TITLE
[MOD] adapt to mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,13 @@ LFT := $(LFTDIR)/libft.a
 CFLAGS := -Wall -Wextra -Werror -I$(LFTDIR)
 LDLIBS := -lreadline
 
-$(NAME): $(LFT) $(MLX) $(OBJECT)
+ifeq ($(shell uname), Darwin)
+	RLDIR := $(shell brew --prefix readline)
+	CFLAGS += -I$(RLDIR)/include
+	LDFLAGS += -L$(RLDIR)/lib
+endif
+
+$(NAME): $(LFT) $(OBJECT)
 	$(LINK.o) $(OBJECT) $(LFT) $(LDLIBS) -o $@
 
 $(LFT): | $(LFTDIR)


### PR DESCRIPTION
MacでもGNU版readlineを使用する様に変更しました。
Macでビルドする際には"brew install readline"してください。