### PR TITLE
[FIX] 複数起動時通常プロンプトのCtrl-Cの挙動を改善

### DIFF
--- a/execute/execute.c
+++ b/execute/execute.c
@@ -85,16 +85,15 @@ static void	wait_pids(t_data *data, pid_t pid)
 			{
 				if (WTERMSIG(status) == SIGQUIT)
 					ft_dprintf(STDERR_FILENO, "Quit\n");
+				else if (WTERMSIG(status) == SIGINT)
+					ft_dprintf(STDERR_FILENO, "\n");
 				data->exit_status = WTERMSIG(status) + 128;
 			}
 		}
-		else if (wpid < 0)
-		{
-			if (errno == ECHILD)
-				break ;
-			else if (errno == EINTR)
-				ft_dprintf(STDERR_FILENO, "\n");
-		}
+		else if (wpid < 0 && errno == ECHILD)
+			break ;
+		else if (wpid < 0 && errno != EINTR)
+			fatal_error("wait");
 	}
 }
 


### PR DESCRIPTION
シグナルを受け取った時のwait()の挙動を改善して、minishellを複数起動してCtrl-Cしても改行が重複しない様にしました。

```
minish$ ./minishell
minish$ ^C
minish$ ^C
minish$ ^C
minish$
```

副作用として`cat | cat | ls`を実行した際の挙動(改行の有無)がbashと差異が出来ます。

minishell：
```
minish$ cat | cat | ls
Makefile   builtin  expand  main.c  minishell    misc   pipeline  tester.sh
README.md  execute  libft   main.o  minishell.h  parse  redirect  tokenize
^Cminish$
```

bash：
```
$ cat | cat | ls
Makefile   builtin  expand  main.c  minishell    misc   pipeline  tester.sh
README.md  execute  libft   main.o  minishell.h  parse  redirect  tokenize
^C
$
```

このbashの挙動はジョブ機能に依存しているはずで、上記を完全に改善するのはジョブを実装しない限り困難だと思います。
より見た目の影響が大きいこちらを修正して、副作用については #80 に記載したいと思います。

close #57 