### PR TITLE
[FIX] #105 #107 #108

### DIFF
--- a/expand/expand.c
+++ b/expand/expand.c
@@ -6,7 +6,7 @@
 /*   By: kadachi <kadachi@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 18:45:07 by kadachi           #+#    #+#             */
-/*   Updated: 2025/04/29 18:45:10 by kadachi          ###   ########.fr       */
+/*   Updated: 2025/05/03 13:40:59 by kadachi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,11 +20,11 @@ void	append_char(char **s, char c)
 	size = 2;
 	if (*s != NULL)
 		size += ft_strlen(*s);
-	new = malloc(size * sizeof(char));
+	new = ft_calloc(size, sizeof(char));
 	if (new == NULL)
 	{
 		free(*s);
-		fatal_error("malloc", strerror(errno));
+		fatal_error("ft_calloc", strerror(errno));
 	}
 	if (*s != NULL)
 		ft_strlcpy(new, *s, size);

--- a/misc/environ.c
+++ b/misc/environ.c
@@ -6,13 +6,13 @@
 /*   By: kadachi <kadachi@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 18:45:36 by kadachi           #+#    #+#             */
-/*   Updated: 2025/05/01 17:19:14 by kadachi          ###   ########.fr       */
+/*   Updated: 2025/05/03 13:41:24 by kadachi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static size_t	envcount(t_env *env)
+static size_t	count_env(t_env *env)
 {
 	size_t	count;
 
@@ -34,15 +34,15 @@ char	**dump_environ(t_env *env)
 
 	if (env == NULL)
 		return (NULL);
-	count = envcount(env);
-	envp = malloc((count + 1) * sizeof(char *));
+	count = count_env(env);
+	envp = ft_calloc(count + 1, sizeof(char *));
 	if (envp == NULL)
 		return (NULL);
 	i = 0;
 	while (i < count)
 	{
 		len = ft_strlen(env->key) + 1 + ft_strlen(env->value) + 1;
-		envp[i] = malloc(len * sizeof(char));
+		envp[i] = ft_calloc(len, sizeof(char));
 		if (envp[i] == NULL)
 			return (free_environ(&envp), NULL);
 		ft_strlcpy(envp[i], env->key, len);
@@ -56,10 +56,13 @@ char	**dump_environ(t_env *env)
 
 void	free_environ(char ***envp)
 {
-	if (*envp == NULL)
+	char	**cur;
+
+	if (envp == NULL || *envp == NULL)
 		return ;
-	while (**envp)
-		free(*(*envp++));
+	cur = *envp;
+	while (*cur)
+		free(*cur++);
 	free(*envp);
 	*envp = NULL;
 }

--- a/tester.sh
+++ b/tester.sh
@@ -82,10 +82,13 @@ assert 1 './a.out'
 # no such command
 assert 1 'a.out'
 assert 1 'nosuchfile'
+assert 1 '/nosuchfile'
 
 # Unquoted args
 assert 1 'ls /'
 assert 1 'echo hello    world'
+assert 1 \'\'
+assert 1 \''/bin/ls test'\'
 
 # Single quote
 assert 1 'echo '\''hello   world'\'' '\''42Tokyo'\'
@@ -94,6 +97,8 @@ assert 1 'echo hello'\''      world'\'
 # Double quote
 assert 1 'echo '\"'hello   world'\"' '\"'42Tokyo'\"
 assert 1 'echo hello'\"'      world'\"
+assert 1 \"\"
+assert 1 \"'/bin/ls test'\"
 
 # Combined quote
 assert 1 'echo '\'\"'hello   world'\"\'' '\''42Tokyo'\'
@@ -168,6 +173,8 @@ assert 1 'echo > | ls'
 assert 1 'echo $USER'
 assert 1 'echo $USER$HOME$PWD'
 assert 1 'echo "$USER  $HOME   $PWD"'
+assert 1 '$NOVAR'
+assert 1 '$NOVAR $NOVAR'
 
 # Expand Parameter
 assert 1 'echo $?'

--- a/tokenize/tokenutils.c
+++ b/tokenize/tokenutils.c
@@ -6,7 +6,7 @@
 /*   By: kadachi <kadachi@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 18:47:08 by kadachi           #+#    #+#             */
-/*   Updated: 2025/05/01 13:58:52 by kadachi          ###   ########.fr       */
+/*   Updated: 2025/05/03 12:47:25 by kadachi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ t_token	*new_token(char *word, t_token_kind kind)
 
 	if (word == NULL)
 		return (NULL);
-	token = malloc(sizeof(t_token));
+	token = ft_calloc(1, sizeof(t_token));
 	if (token == NULL)
 		return (NULL);
 	token->word = word;


### PR DESCRIPTION
#105 #107 #108に対応しました。修正点は以下です。

- free_environ()でセグフォしていたのを修正
これによりfork()した子プロセスがexecve()出来ない時の終了処理でセグフォしていた
- execute()の時点でノードが存在するかを確認して無ければexit_statusを0にして次のプロンプトに移る
ワードスプリッティングの結果によりノードが存在しない場合がありその場合の分岐処理が必要だった
- execute_command()で正常にerrnoを参照できていなかった点を修正
errnoはシステムコールの度に値を更新するためfree()等の終了処理で値が変わっていた。

close #105
close #107
close #108