### PR TITLE
[FIX] #110

### DIFF
--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: kadachi <kadachi@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 18:51:30 by kadachi           #+#    #+#             */
-/*   Updated: 2025/05/02 16:05:09 by kadachi          ###   ########.fr       */
+/*   Updated: 2025/05/03 19:05:54 by kadachi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -158,7 +158,7 @@ void	free_argv(char ***argv);
 char	*find_path(t_env *env, char path[PATH_MAX], char *line);
 
 // redirect/redirect.c
-void	setup_redirect(t_node *redi);
+int		setup_redirect(t_node *redi);
 void	reset_redirect(t_node *redi);
 
 // pipeline/pipeline.c

--- a/parse/nodeutils.c
+++ b/parse/nodeutils.c
@@ -6,7 +6,7 @@
 /*   By: kadachi <kadachi@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 18:46:11 by kadachi           #+#    #+#             */
-/*   Updated: 2025/05/01 17:28:14 by kadachi          ###   ########.fr       */
+/*   Updated: 2025/05/03 19:23:45 by kadachi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,7 @@ t_node	*new_node(t_node_kind kind)
 	if (node == NULL)
 		return (NULL);
 	node->kind = kind;
+	node->stashed_fd = -1;
 	return (node);
 }
 

--- a/redirect/redirect.c
+++ b/redirect/redirect.c
@@ -6,33 +6,40 @@
 /*   By: kadachi <kadachi@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 18:46:34 by kadachi           #+#    #+#             */
-/*   Updated: 2025/05/01 17:12:54 by kadachi          ###   ########.fr       */
+/*   Updated: 2025/05/03 19:32:04 by kadachi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
-static void	open_redirect(t_node *redi, int srcfd, int flags, mode_t mode)
+static int	open_redirect(t_node *redi, int srcfd, int flags, mode_t mode)
 {
 	int	dstfd;
 
 	dstfd = open(redi->args->word, flags, mode);
 	if (dstfd < 0)
-		fatal_error(redi->args->word, strerror(errno));
+	{
+		ft_dprintf(STDERR, HEADER "open: %s\n", strerror(errno));
+		return (errno);
+	}
 	redi->stashed_fd = dup(srcfd);
 	if (redi->stashed_fd < 0)
 		fatal_error("dup", strerror(errno));
 	if (dup2(dstfd, srcfd) < 0)
 		fatal_error("dup2", strerror(errno));
-	close(dstfd);
+	if (close(dstfd) < 0)
+		fatal_error("close", strerror(errno));
+	return (0);
 }
 
 static void	write_heredoc(int fd, t_token *token)
 {
 	if (token == NULL)
 		return ;
-	write(fd, token->word, ft_strlen(token->word));
-	write(fd, "\n", 1);
+	if (write(fd, token->word, ft_strlen(token->word)) < 0)
+		fatal_error("write", strerror(errno));
+	if (write(fd, "\n", 1) < 0)
+		fatal_error("write", strerror(errno));
 	write_heredoc(fd, token->next);
 }
 
@@ -43,27 +50,34 @@ static void	open_heredoc(t_node *redi)
 	if (pipe(pipefd) < 0)
 		fatal_error("pipe", strerror(errno));
 	write_heredoc(pipefd[1], redi->args->next);
-	close(pipefd[1]);
+	if (close(pipefd[1]) < 0)
+		fatal_error("close", strerror(errno));
 	redi->stashed_fd = dup(STDIN);
 	if (redi->stashed_fd < 0)
 		fatal_error("dup", strerror(errno));
 	if (dup2(pipefd[0], STDIN) < 0)
 		fatal_error("dup2", strerror(errno));
-	close(pipefd[0]);
+	if (close(pipefd[0]) < 0)
+		fatal_error("close", strerror(errno));
 }
 
-void	setup_redirect(t_node *redi)
+int	setup_redirect(t_node *redi)
 {
+	int	ret;
+
+	ret = 0;
 	if (redi == NULL)
-		return ;
+		return (0);
 	if (redi->kind == ND_REDIR_OUT)
-		open_redirect(redi, STDOUT, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+		ret = open_redirect(redi, STDOUT, O_CREAT | O_WRONLY | O_TRUNC, 0644);
 	else if (redi->kind == ND_REDIR_IN)
-		open_redirect(redi, STDIN, O_RDONLY, 0644);
+		ret = open_redirect(redi, STDIN, O_RDONLY, 0644);
 	else if (redi->kind == ND_REDIR_APPEND)
-		open_redirect(redi, STDOUT, O_CREAT | O_WRONLY | O_APPEND, 0644);
+		ret = open_redirect(redi, STDOUT, O_CREAT | O_WRONLY | O_APPEND, 0644);
 	else if (redi->kind == ND_REDIR_HEREDOC)
 		open_heredoc(redi);
+	if (ret != 0)
+		return (ret);
 	return (setup_redirect(redi->next));
 }
 
@@ -71,7 +85,7 @@ void	reset_redirect(t_node *redi)
 {
 	int	fd;
 
-	if (redi == NULL)
+	if (redi == NULL || redi->stashed_fd < 0)
 		return ;
 	reset_redirect(redi->next);
 	if (redi->kind == ND_REDIR_IN || redi->kind == ND_REDIR_HEREDOC)
@@ -80,5 +94,6 @@ void	reset_redirect(t_node *redi)
 		fd = STDOUT;
 	if (dup2(redi->stashed_fd, fd) < 0)
 		fatal_error("dup2", strerror(errno));
-	close(redi->stashed_fd);
+	if (close(redi->stashed_fd) < 0)
+		fatal_error("close", strerror(errno));
 }

--- a/tester.sh
+++ b/tester.sh
@@ -156,8 +156,12 @@ assert 1 'cat <<EO"F" \n$USER\n$NO_SUCH_VAR\n$FOO$BAR\nEOF'
 export EOF="eof"
 assert 1 'cat <<$EOF         \neof\n$EOF\nEOF'
 assert 1 'cat <<"$EOF"       \neof\n$EOF\nEOF'
+unset EOF
 assert 1 '<<'
 assert 1 'cat <<'
+assert 1 'echo test > .'
+assert 1 'echo test | echo test > .'
+assert 1 'echo test > . | echo test'
 
 # Pipe
 assert 1 'cat Makefile | grep minishell'
@@ -343,6 +347,7 @@ assert 1 'export [NG]=test\nenv|sort|grep -vE "$BLKLST"'
 assert 1 'export [NG]=te =st\nenv|sort|grep -vE "$BLKLST"'
 assert 1 'export HO=[OK] GE=tst\nenv|sort|grep -vE "$BLKLST"'
 assert 1 'export HO="HO=hoge"\nenv|sort|grep -vE "$BLKLST"'
+unset BLKLST
 
 ## echo
 assert 1 'echo'
@@ -368,6 +373,7 @@ assert 1 'unset NOVAR\necho $TEST1 $TEST2'
 assert 1 'unset novar\necho $TEST1 $TEST2'
 assert 1 'unset TEST1 TEST2\necho $TEST1 $TEST2'
 assert 1 'unset TEST1 NOVAR TEST2\necho $TEST1 $TEST2'
+unset TEST1 TEST2
 
 # env
 assert 1 'env | vgrep "OLDPWD|SHLVL|_="'


### PR DESCRIPTION
対応しました。

setup_redirect()のopen()実行時のみエラー処理をexecute_command/builtin()まで引っ張ってきてそれぞれで処理する様に変更しました。
また、t_nodeの初期化時にstashed_fdを無効な値にしていないせいで単独のビルトイン関数でのopen()失敗時にreset_redirect()が適切に処理できていない点も修正しました。

close #110 