### PR TITLE
[FIX] #127

### DIFF
--- a/execute/find_path.c
+++ b/execute/find_path.c
@@ -6,7 +6,7 @@
 /*   By: kadachi <kadachi@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/01 16:45:37 by kadachi           #+#    #+#             */
-/*   Updated: 2025/05/03 18:02:25 by kadachi          ###   ########.fr       */
+/*   Updated: 2025/05/04 17:36:26 by kadachi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,9 @@ char	*find_path(t_env *env, char path[PATH_MAX], char *line)
 	if (ft_strchr(line, '/'))
 		return (ft_strlcpy(path, line, PATH_MAX), path);
 	env_value = get_env(env, "PATH");
-	while (line && *line && env_value && *env_value)
+	if (env_value == NULL)
+		return (ft_strlcpy(path, line, PATH_MAX), path);
+	while (line && *line && *env_value)
 	{
 		ft_bzero(path, PATH_MAX);
 		end = ft_strchr(env_value, ':');

--- a/tester.sh
+++ b/tester.sh
@@ -379,6 +379,8 @@ assert 1 'unset novar\necho $TEST1 $TEST2'
 assert 1 'unset TEST1 TEST2\necho $TEST1 $TEST2'
 assert 1 'unset TEST1 NOVAR TEST2\necho $TEST1 $TEST2'
 unset TEST1 TEST2
+assert 1 'unset PATH\nls'
+assert 1 'cd /usr/bin\nunset PATH\nls'
 
 # env
 assert 1 'env | vgrep "OLDPWD|SHLVL|_="'


### PR DESCRIPTION
find_path()でPATHが取得出来なかった場合にコマンド実行を中止するのではなく相対パスの値を直接execve()に投げることで対応しました。巻き込みで #89 が解決します。

close #127
close #89 
